### PR TITLE
Add notebook descriptions and preserve Unicode in JSON

### DIFF
--- a/src/NotebookMcpServer/Interfaces/INotebookService.cs
+++ b/src/NotebookMcpServer/Interfaces/INotebookService.cs
@@ -41,4 +41,12 @@ public interface INotebookService
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if the entry was deleted, false if it didn't exist</returns>
     Task<bool> DeleteEntryAsync(string notebookName, string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a notebook or update its description
+    /// </summary>
+    /// <param name="notebookName">Name of the notebook</param>
+    /// <param name="description">Notebook description</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task CreateNotebookAsync(string notebookName, string description, CancellationToken cancellationToken = default);
 }

--- a/src/NotebookMcpServer/Models/Notebook.cs
+++ b/src/NotebookMcpServer/Models/Notebook.cs
@@ -6,6 +6,7 @@ namespace NotebookMcpServer.Models;
 public record Notebook
 {
     public required string Name { get; init; }
+    public string? Description { get; set; }
     public Dictionary<string, NotebookEntry> Entries { get; init; } =[];
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
     public DateTime ModifiedAt { get; set; } = DateTime.UtcNow;

--- a/src/NotebookMcpServer/Services/FileNotebookStorageService.cs
+++ b/src/NotebookMcpServer/Services/FileNotebookStorageService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using NotebookMcpServer.Interfaces;
 using NotebookMcpServer.Models;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 
 namespace NotebookMcpServer.Services;
@@ -17,6 +18,7 @@ public class FileNotebookStorageService : INotebookStorageService, IDisposable
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
     private readonly SemaphoreSlim _globalSemaphore;
     private volatile bool _disposed;

--- a/src/NotebookMcpServer/Services/NotebookService.cs
+++ b/src/NotebookMcpServer/Services/NotebookService.cs
@@ -123,4 +123,19 @@ public class NotebookService : INotebookService
         _logger.LogInformation("Successfully deleted entry '{Key}' from notebook '{NotebookName}'", key, notebookName);
         return true;
     }
+
+    public async Task CreateNotebookAsync(string notebookName, string description, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(notebookName);
+        description ??= string.Empty;
+
+        _logger.LogInformation("Creating or updating notebook '{NotebookName}'", notebookName);
+
+        var notebook = await _storageService.LoadNotebookAsync(notebookName, cancellationToken) ?? new Notebook { Name = notebookName };
+        notebook.Description = description;
+
+        await _storageService.SaveNotebookAsync(notebook, cancellationToken);
+
+        _logger.LogInformation("Notebook '{NotebookName}' saved with description", notebookName);
+    }
 }

--- a/src/NotebookMcpServer/Tools/NotebookTools.cs
+++ b/src/NotebookMcpServer/Tools/NotebookTools.cs
@@ -19,6 +19,24 @@ namespace NotebookMcpServer.Tools;
         _notebookService = notebookService;
     }
 
+    [McpServerTool(Name = "create_notebook")]
+    [Description("Create a notebook or update its description. Example: { \"notebookName\": \"spanish\", \"description\": \"Spanish vocabulary\" }")]
+    public async Task<string> CreateNotebookAsync(
+        [Description("Exact name of the notebook (case‑sensitive, non-empty).")]
+        string notebookName,
+        [Description("Description to store for the notebook.")]
+        string description)
+    {
+        if (string.IsNullOrWhiteSpace(notebookName))
+        {
+            throw new ArgumentException("Notebook name must be a non-empty string.", nameof(notebookName));
+        }
+
+        description ??= string.Empty;
+        await _notebookService.CreateNotebookAsync(notebookName, description);
+        return $"Notebook '{notebookName}' has been created or updated.";
+    }
+
     /// <summary>
     /// Returns all entries of the specified notebook as a dictionary (key → value).
     /// </summary>

--- a/tests/NotebookMcpServer.Tests/NotebookServiceTests.cs
+++ b/tests/NotebookMcpServer.Tests/NotebookServiceTests.cs
@@ -208,6 +208,29 @@ public class NotebookServiceTests
     }
 
     [Fact]
+    public async Task CreateNotebookAsync_NewNotebook_SetsDescription()
+    {
+        var (storageService, notebookService) = CreateServices();
+
+        await notebookService.CreateNotebookAsync("book", "описание");
+
+        var notebook = await storageService.LoadNotebookAsync("book");
+        Assert.Equal("описание", notebook?.Description);
+    }
+
+    [Fact]
+    public async Task CreateNotebookAsync_ExistingNotebook_UpdatesDescription()
+    {
+        var (storageService, notebookService) = CreateServices();
+
+        await notebookService.CreateNotebookAsync("book", "first");
+        await notebookService.CreateNotebookAsync("book", "second");
+
+        var notebook = await storageService.LoadNotebookAsync("book");
+        Assert.Equal("second", notebook?.Description);
+    }
+
+    [Fact]
     public async Task WriteEntryAsync_NullNotebookName_ThrowsArgumentException()
     {
         var (storageService, notebookService) = CreateServices();


### PR DESCRIPTION
## Summary
- allow unescaped Unicode when serializing notebooks
- add description field for notebooks with command to create/update it
- cover notebook description and Unicode persistence with tests

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b820331014832aad5f20dbeca32efa