### PR TITLE
Refactor notebook entries into pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Notebook MCP Server
 
-A Model Context Protocol (MCP) server for managing key-value notebooks with persistent file storage.
+A Model Context Protocol (MCP) server for managing notebooks with pages of text and persistent file storage.
 
 ## Overview
 
-This MCP server provides tools for creating, viewing, updating, and managing key-value notebooks. Each notebook is stored as a separate JSON file, with thread-safe operations and proper concurrency control.
+This MCP server provides tools for creating, viewing, updating, and managing notebooks that store page/text pairs. Each notebook is stored as a separate JSON file, with thread-safe operations and proper concurrency control.
 
 ## Features
 
-- **Key-Value Storage**: Store and retrieve key-value pairs in named notebooks
+- **Page Storage**: Store and retrieve pages with text in named notebooks
 - **Persistent Storage**: Data is stored in JSON files for persistence
 - **Thread-Safe Operations**: Uses semaphores for concurrent access protection
 - **Separate Files**: Each notebook is stored in its own JSON file
@@ -18,13 +18,13 @@ This MCP server provides tools for creating, viewing, updating, and managing key
 
 ## Available Tools
 
-### 1. View Notebook (`view_notebook`)
-Retrieves all key-value pairs from a notebook.
+### 1. Get Notebook Pages (`get_notebook_pages`)
+Retrieves all pages with their text from a notebook.
 
 **Parameters:**
 - `notebook_name` (string): Name of the notebook to view
 
-**Returns:** Dictionary of key-value pairs
+**Returns:** Dictionary of page-text pairs
 
 **Example:**
 ```json
@@ -33,13 +33,13 @@ Retrieves all key-value pairs from a notebook.
 }
 ```
 
-### 2. Write Entry (`write_entry`)
-Creates or updates a key-value pair in a notebook.
+### 2. Upsert Page (`upsert_page`)
+Creates or updates a page in a notebook.
 
 **Parameters:**
 - `notebook_name` (string): Name of the notebook
-- `key` (string): The key to store/update
-- `value` (string): The value to store
+- `page` (string): Page name to store/update
+- `text` (string): Text to store on the page
 
 **Returns:** Success confirmation
 
@@ -47,17 +47,17 @@ Creates or updates a key-value pair in a notebook.
 ```json
 {
   "notebook_name": "my-notebook",
-  "key": "important-note",
-  "value": "Remember to update documentation"
+  "page": "important-note",
+  "text": "Remember to update documentation"
 }
 ```
 
-### 3. Delete Entry (`delete_entry`)
-Deletes a specific key from a notebook.
+### 3. Remove Page (`remove_page`)
+Deletes a specific page from a notebook.
 
 **Parameters:**
 - `notebook_name` (string): Name of the notebook
-- `key` (string): The key to delete
+- `page` (string): The page to delete
 
 **Returns:** Boolean indicating success/failure
 
@@ -65,15 +65,15 @@ Deletes a specific key from a notebook.
 ```json
 {
   "notebook_name": "my-notebook",
-  "key": "obsolete-note"
+  "page": "obsolete-note"
 }
 ```
 
 ## Architecture
 
 ### Models
-- `NotebookEntry`: Represents a single key-value entry with timestamps
-- `Notebook`: Contains a collection of entries with metadata
+- `NotebookPage`: Represents a single page with text and timestamps
+  - `Notebook`: Contains a collection of pages with metadata
 
 ### Services
 - `INotebookStorageService`: Interface for storage operations
@@ -94,10 +94,10 @@ The JSON structure includes:
 ```json
 {
   "Name": "my-notebook",
-  "Entries": {
-    "key1": {
-      "Key": "key1",
-      "Value": "value1",
+  "Pages": {
+    "page1": {
+      "Page": "page1",
+      "Text": "text1",
       "CreatedAt": "2024-01-15T10:30:00Z",
       "ModifiedAt": "2024-01-15T10:30:00Z"
     }
@@ -260,9 +260,9 @@ The server uses semaphores to ensure thread-safe file operations:
 This server is designed to work with MCP-compatible clients. The client connects via stdio and can invoke the available tools to manage notebooks.
 
 Example workflow:
-1. Use `view_notebook` to check existing entries
-2. Use `write_entry` to add or update entries
-3. Use `delete_entry` to remove obsolete entries
+1. Use `get_notebook_pages` to check existing pages
+2. Use `upsert_page` to add or update pages
+3. Use `remove_page` to remove obsolete pages
 
 ## Contributing
 

--- a/src/NotebookMcpServer/Interfaces/INotebookService.cs
+++ b/src/NotebookMcpServer/Interfaces/INotebookService.cs
@@ -8,39 +8,39 @@ namespace NotebookMcpServer.Interfaces;
 public interface INotebookService
 {
     /// <summary>
-    /// Get all entries from a notebook
+    /// Get all pages from a notebook
     /// </summary>
     /// <param name="notebookName">Name of the notebook</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Dictionary of all entries in the notebook</returns>
+    /// <returns>Dictionary of all pages in the notebook</returns>
     Task<Dictionary<string, string>> ViewNotebookAsync(string notebookName, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get a single entry's value from a notebook
+    /// Get text of a single page from a notebook
     /// </summary>
     /// <param name="notebookName">Name of the notebook</param>
-    /// <param name="key">Entry key</param>
+    /// <param name="page">Page name</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Entry value or empty string if not found</returns>
-    Task<string> GetEntryAsync(string notebookName, string key, CancellationToken cancellationToken = default);
+    /// <returns>Page text or empty string if not found</returns>
+    Task<string> GetPageAsync(string notebookName, string page, CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Write or update an entry in a notebook
+    /// Write or update a page in a notebook
     /// </summary>
     /// <param name="notebookName">Name of the notebook</param>
-    /// <param name="key">Entry key</param>
-    /// <param name="value">Entry value</param>
+    /// <param name="page">Page name</param>
+    /// <param name="text">Page text</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task WriteEntryAsync(string notebookName, string key, string value, CancellationToken cancellationToken = default);
+    Task WritePageAsync(string notebookName, string page, string text, CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Delete an entry from a notebook
+    /// Delete a page from a notebook
     /// </summary>
     /// <param name="notebookName">Name of the notebook</param>
-    /// <param name="key">Entry key to delete</param>
+    /// <param name="page">Page name to delete</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>True if the entry was deleted, false if it didn't exist</returns>
-    Task<bool> DeleteEntryAsync(string notebookName, string key, CancellationToken cancellationToken = default);
+    /// <returns>True if the page was deleted, false if it didn't exist</returns>
+    Task<bool> DeletePageAsync(string notebookName, string page, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a notebook or update its description

--- a/src/NotebookMcpServer/Models/Notebook.cs
+++ b/src/NotebookMcpServer/Models/Notebook.cs
@@ -1,13 +1,13 @@
 namespace NotebookMcpServer.Models;
 
 /// <summary>
-/// Complete notebook with indexed entries and timestamps.
+/// Complete notebook with pages and timestamps.
 /// </summary>
 public record Notebook
 {
     public required string Name { get; init; }
     public string? Description { get; set; }
-    public Dictionary<string, NotebookEntry> Entries { get; init; } =[];
+    public Dictionary<string, NotebookPage> Pages { get; init; } = [];
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
     public DateTime ModifiedAt { get; set; } = DateTime.UtcNow;
 }

--- a/src/NotebookMcpServer/Models/NotebookPage.cs
+++ b/src/NotebookMcpServer/Models/NotebookPage.cs
@@ -1,12 +1,12 @@
 namespace NotebookMcpServer.Models;
 
 /// <summary>
-/// Key-value entry in a notebook with timestamps.
+/// Page with text in a notebook with timestamps.
 /// </summary>
-public record NotebookEntry
+public record NotebookPage
 {
-    public required string Key { get; init; }
-    public required string Value { get; init; }
+    public required string Page { get; init; }
+    public required string Text { get; init; }
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
     public DateTime ModifiedAt { get; init; } = DateTime.UtcNow;
 }

--- a/src/NotebookMcpServer/NotebookMcpServer.csproj
+++ b/src/NotebookMcpServer/NotebookMcpServer.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyTitle>Notebook MCP Server</AssemblyTitle>
-    <AssemblyDescription>Model Context Protocol server for managing notebooks with key-value entries, built with MCPSharp v1.0.11</AssemblyDescription>
+    <AssemblyDescription>Model Context Protocol server for managing notebooks with pages of text, built with MCPSharp v1.0.11</AssemblyDescription>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>

--- a/src/NotebookMcpServer/Program.cs
+++ b/src/NotebookMcpServer/Program.cs
@@ -39,7 +39,7 @@ internal sealed class Program
         {
             Console.WriteLine("Notebook MCP Server");
             Console.WriteLine();
-            Console.WriteLine("A Model Context Protocol (MCP) server for managing key-value notebooks with persistent file storage.");
+            Console.WriteLine("A Model Context Protocol (MCP) server for managing notebooks with pages of text and persistent file storage.");
             Console.WriteLine();
             Console.WriteLine("Usage:");
             Console.WriteLine("  NotebookMcpServer [options]");

--- a/src/NotebookMcpServer/Services/FileNotebookStorageService.cs
+++ b/src/NotebookMcpServer/Services/FileNotebookStorageService.cs
@@ -61,8 +61,8 @@ public class FileNotebookStorageService : INotebookStorageService, IDisposable
             var notebook = await JsonSerializer.DeserializeAsync<Notebook>(stream, JsonOptions, cancellationToken);
 
             _logger.LogDebug(
-                "Successfully loaded notebook '{NotebookName}' with {EntryCount} entries",
-                notebookName, notebook?.Entries.Count ?? 0);
+                "Successfully loaded notebook '{NotebookName}' with {PageCount} pages",
+                notebookName, notebook?.Pages.Count ?? 0);
 
             return notebook;
         }
@@ -101,8 +101,8 @@ public class FileNotebookStorageService : INotebookStorageService, IDisposable
             await stream.FlushAsync(cancellationToken);
 
             _logger.LogDebug(
-                "Successfully saved notebook '{NotebookName}' with {EntryCount} entries",
-                notebook.Name, notebook.Entries.Count);
+                "Successfully saved notebook '{NotebookName}' with {PageCount} pages",
+                notebook.Name, notebook.Pages.Count);
         }
         catch (Exception ex)
         {

--- a/src/NotebookMcpServer/Tools/NotebookTools.cs
+++ b/src/NotebookMcpServer/Tools/NotebookTools.cs
@@ -5,11 +5,11 @@ using System.ComponentModel;
 namespace NotebookMcpServer.Tools;
 
 /// <summary>
-/// MCP tools for working with "notebooks" — named collections of string key/value pairs.
-/// Provides read (list entries), upsert (create or overwrite), and delete operations.
+/// MCP tools for working with notebooks as collections of page/text pairs.
+/// Provides read (list pages), upsert, and delete operations.
 /// </summary>
 [McpServerToolType]
-[Description("Tools for viewing, upserting, and deleting string key/value entries in named notebooks.")]
+[Description("Tools for viewing, upserting, and deleting pages in named notebooks.")]
     public class NotebookTools
     {
         private readonly INotebookService _notebookService;
@@ -38,13 +38,13 @@ namespace NotebookMcpServer.Tools;
     }
 
     /// <summary>
-    /// Returns all entries of the specified notebook as a dictionary (key → value).
+    /// Returns all pages of the specified notebook as a dictionary (page → text).
     /// </summary>
     /// <param name="notebookName">Exact name of the target notebook (case‑sensitive, non-empty).</param>
-    /// <returns>A dictionary of current entries in the notebook.</returns>
-    [McpServerTool(Name = "get_notebook_entries")]
-    [Description("List all key/value entries in the specified notebook. Example: { \"notebookName\": \"spanish\" }")]
-        public async Task<Dictionary<string, string>> GetNotebookEntriesAsync(
+    /// <returns>A dictionary of current pages in the notebook.</returns>
+    [McpServerTool(Name = "get_notebook_pages")]
+    [Description("List all pages in the specified notebook. Example: { \"notebookName\": \"spanish\" }")]
+        public async Task<Dictionary<string, string>> GetNotebookPagesAsync(
             [Description("Exact name of the notebook to read (case‑sensitive, non-empty).")]
             string notebookName)
         {
@@ -57,93 +57,93 @@ namespace NotebookMcpServer.Tools;
         }
 
         /// <summary>
-        /// Returns the value of a single entry from the specified notebook.
+        /// Returns the text of a single page from the specified notebook.
         /// </summary>
         /// <param name="notebookName">Exact name of the target notebook (case‑sensitive, non-empty).</param>
-        /// <param name="key">Key to read (non-empty).</param>
-        /// <returns>Value of the entry or an empty string if not found.</returns>
-        [McpServerTool(Name = "get_entry")]
-        [Description("Read a single key from a notebook. Example: { \"notebookName\": \"spanish\", \"key\": \"hola\" }")]
-        public async Task<string> GetEntryAsync(
+        /// <param name="page">Page name to read (non-empty).</param>
+        /// <returns>Text of the page or an empty string if not found.</returns>
+        [McpServerTool(Name = "get_page_text")]
+        [Description("Read a single page from a notebook. Example: { \"notebookName\": \"spanish\", \"page\": \"hola\" }")]
+        public async Task<string> GetPageTextAsync(
             [Description("Exact name of the notebook to read (case‑sensitive, non-empty).")]
             string notebookName,
-            [Description("Key to read from the notebook (non-empty string).")]
-            string key)
+            [Description("Page to read from the notebook (non-empty string).")]
+            string page)
         {
             if (string.IsNullOrWhiteSpace(notebookName))
             {
                 throw new ArgumentException("Notebook name must be a non-empty string.", nameof(notebookName));
             }
 
-            if (string.IsNullOrWhiteSpace(key))
+            if (string.IsNullOrWhiteSpace(page))
             {
-                throw new ArgumentException("Key must be a non-empty string.", nameof(key));
+                throw new ArgumentException("Page must be a non-empty string.", nameof(page));
             }
 
-            return await _notebookService.GetEntryAsync(notebookName, key);
+            return await _notebookService.GetPageAsync(notebookName, page);
         }
 
     /// <summary>
-    /// Creates or overwrites a single entry (key → value) in the specified notebook.
+    /// Creates or overwrites a single page in the specified notebook.
     /// </summary>
     /// <param name="notebookName">Exact name of the target notebook (case‑sensitive, non-empty).</param>
-    /// <param name="key">Entry key (non-empty; unique within the notebook). Existing value will be overwritten.</param>
-    /// <param name="value">Entry value to store (string, stored verbatim; null is not allowed).</param>
+    /// <param name="page">Page name (non-empty; unique within the notebook). Existing text will be overwritten.</param>
+    /// <param name="text">Text to store for the page (string, stored verbatim; null is not allowed).</param>
     /// <returns>Operation status as a short human-readable message.</returns>
-    [McpServerTool(Name = "upsert_entry")]
-    [Description("Create or update a key/value entry in a notebook. Example: { \"notebookName\": \"spanish\", \"key\": \"acogedor\", \"value\": \"cozy, welcoming\" }")]
-    public async Task<string> UpsertEntryAsync(
+    [McpServerTool(Name = "upsert_page")]
+    [Description("Create or update a page in a notebook. Example: { \"notebookName\": \"spanish\", \"page\": \"acogedor\", \"text\": \"cozy, welcoming\" }")]
+    public async Task<string> UpsertPageAsync(
         [Description("Exact name of the target notebook (case‑sensitive, non-empty).")]
         string notebookName,
-        [Description("Key to create or update (non-empty string). Existing value will be overwritten.")]
-        string key,
-        [Description("Value to store for the key (string, stored verbatim; must not be null).")]
-        string value)
+        [Description("Page to create or update (non-empty string). Existing text will be overwritten.")]
+        string page,
+        [Description("Text to store for the page (string, stored verbatim; must not be null).")]
+        string text)
     {
         if (string.IsNullOrWhiteSpace(notebookName))
         {
             throw new ArgumentException("Notebook name must be a non-empty string.", nameof(notebookName));
         }
 
-        if (string.IsNullOrWhiteSpace(key))
+        if (string.IsNullOrWhiteSpace(page))
         {
-            throw new ArgumentException("Key must be a non-empty string.", nameof(key));
+            throw new ArgumentException("Page must be a non-empty string.", nameof(page));
         }
 
-        if (value is null)
+        if (text is null)
         {
-            throw new ArgumentNullException(nameof(value), "Value must not be null. Use an empty string if appropriate.");
+            throw new ArgumentNullException(nameof(text), "Text must not be null. Use an empty string if appropriate.");
         }
 
-        await _notebookService.WriteEntryAsync(notebookName, key, value);
-        return $"Entry '{key}' has been upserted in notebook '{notebookName}'.";
+        await _notebookService.WritePageAsync(notebookName, page, text);
+        return $"Page '{page}' has been upserted in notebook '{notebookName}'.";
     }
 
     /// <summary>
-    /// Deletes a single entry from the specified notebook.
+    /// Deletes a single page from the specified notebook.
     /// </summary>
     /// <param name="notebookName">Exact name of the target notebook (case‑sensitive, non-empty).</param>
-    /// <param name="key">Key of the entry to delete (non-empty).</param>
-    /// <returns><c>true</c> if the entry existed and was deleted; otherwise <c>false</c>.</returns>
-    [McpServerTool(Name = "remove_entry")]
-    [Description("Delete a single key from a notebook. Returns true if deleted, false if not found. Example: { \"notebookName\": \"spanish\", \"key\": \"acogedor\" }")]
-    public async Task<bool> RemoveEntryAsync(
+    /// <param name="page">Page name to delete (non-empty).</param>
+    /// <returns><c>true</c> if the page existed and was deleted; otherwise <c>false</c>.</returns>
+    [McpServerTool(Name = "remove_page")]
+    [Description("Delete a single page from a notebook. Returns true if deleted, false if not found. Example: { \"notebookName\": \"spanish\", \"page\": \"acogedor\" }")]
+    public async Task<bool> RemovePageAsync(
         [Description("Exact name of the target notebook (case‑sensitive, non-empty).")]
         string notebookName,
-        [Description("Key to delete from the notebook (non-empty string).")]
-        string key)
+        [Description("Page to delete from the notebook (non-empty string).")]
+        string page)
     {
         if (string.IsNullOrWhiteSpace(notebookName))
         {
             throw new ArgumentException("Notebook name must be a non-empty string.", nameof(notebookName));
         }
 
-        if (string.IsNullOrWhiteSpace(key))
+        if (string.IsNullOrWhiteSpace(page))
         {
-            throw new ArgumentException("Key must be a non-empty string.", nameof(key));
+            throw new ArgumentException("Page must be a non-empty string.", nameof(page));
         }
 
-        return await _notebookService.DeleteEntryAsync(notebookName, key);
+        return await _notebookService.DeletePageAsync(notebookName, page);
     }
 
 }

--- a/tests/NotebookMcpServer.Tests/NotebookMcpServerIntegrationTests.cs
+++ b/tests/NotebookMcpServer.Tests/NotebookMcpServerIntegrationTests.cs
@@ -58,80 +58,80 @@ public class NotebookMcpServerIntegrationTests : IDisposable
     {
         // Arrange
         const string notebookName = "integration-test-notebook";
-        const string testKey1 = "user-preference";
-        const string testValue1 = "dark-theme";
-        const string testKey2 = "last-login";
-        const string testValue2 = "2024-01-15T10:30:00Z";
-        const string updatedValue1 = "light-theme";
+        const string testPage1 = "user-preference";
+        const string testText1 = "dark-theme";
+        const string testPage2 = "last-login";
+        const string testText2 = "2024-01-15T10:30:00Z";
+        const string updatedText1 = "light-theme";
 
         // Act & Assert: CREATE operations
 
         // 1. View empty notebook (should return empty dictionary)
-        Dictionary<string, string> emptyNotebook = await _notebookTools.GetNotebookEntriesAsync(notebookName);
+        Dictionary<string, string> emptyNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
         Assert.NotNull(emptyNotebook);
         Assert.Empty(emptyNotebook);
 
-        // 2. Write first entry
-        string writeResult1 = await _notebookTools.UpsertEntryAsync(notebookName, testKey1, testValue1);
+        // 2. Write first page
+        string writeResult1 = await _notebookTools.UpsertPageAsync(notebookName, testPage1, testText1);
         Assert.Contains("has been upserted", writeResult1);
-        Assert.Contains(testKey1, writeResult1);
+        Assert.Contains(testPage1, writeResult1);
         Assert.Contains(notebookName, writeResult1);
 
-        // 2a. Read first entry
-        string readValue1 = await _notebookTools.GetEntryAsync(notebookName, testKey1);
-        Assert.Equal(testValue1, readValue1);
+        // 2a. Read first page
+        string readText1 = await _notebookTools.GetPageTextAsync(notebookName, testPage1);
+        Assert.Equal(testText1, readText1);
 
-        // 3. Write second entry
-        string writeResult2 = await _notebookTools.UpsertEntryAsync(notebookName, testKey2, testValue2);
+        // 3. Write second page
+        string writeResult2 = await _notebookTools.UpsertPageAsync(notebookName, testPage2, testText2);
         Assert.Contains("has been upserted", writeResult2);
 
         // Act & Assert: READ operations
 
-        // 4. View notebook with entries
-        Dictionary<string, string> notebookWithEntries = await _notebookTools.GetNotebookEntriesAsync(notebookName);
-        Assert.NotNull(notebookWithEntries);
-        Assert.Equal(2, notebookWithEntries.Count);
-        Assert.Equal(testValue1, notebookWithEntries[testKey1]);
-        Assert.Equal(testValue2, notebookWithEntries[testKey2]);
+        // 4. View notebook with pages
+        Dictionary<string, string> notebookWithPages = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        Assert.NotNull(notebookWithPages);
+        Assert.Equal(2, notebookWithPages.Count);
+        Assert.Equal(testText1, notebookWithPages[testPage1]);
+        Assert.Equal(testText2, notebookWithPages[testPage2]);
 
         // Act & Assert: UPDATE operations
 
-        // 5. Update existing entry
-        string updateResult = await _notebookTools.UpsertEntryAsync(notebookName, testKey1, updatedValue1);
+        // 5. Update existing page
+        string updateResult = await _notebookTools.UpsertPageAsync(notebookName, testPage1, updatedText1);
         Assert.Contains("has been upserted", updateResult);
 
         // 6. Verify update
-        Dictionary<string, string> updatedNotebook = await _notebookTools.GetNotebookEntriesAsync(notebookName);
+        Dictionary<string, string> updatedNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
         Assert.Equal(2, updatedNotebook.Count);
-        Assert.Equal(updatedValue1, updatedNotebook[testKey1]);
-        Assert.Equal(testValue2, updatedNotebook[testKey2]); // This should remain unchanged
+        Assert.Equal(updatedText1, updatedNotebook[testPage1]);
+        Assert.Equal(testText2, updatedNotebook[testPage2]); // This should remain unchanged
 
         // Act & Assert: DELETE operations
 
-        // 7. Delete one entry
-        bool deleteResult = await _notebookTools.RemoveEntryAsync(notebookName, testKey2);
+        // 7. Delete one page
+        bool deleteResult = await _notebookTools.RemovePageAsync(notebookName, testPage2);
         Assert.True(deleteResult);
 
         // 8. Verify deletion
-        Dictionary<string, string> notebookAfterDelete = await _notebookTools.GetNotebookEntriesAsync(notebookName);
+        Dictionary<string, string> notebookAfterDelete = await _notebookTools.GetNotebookPagesAsync(notebookName);
         Assert.Single(notebookAfterDelete);
-        Assert.Equal(updatedValue1, notebookAfterDelete[testKey1]);
-        Assert.False(notebookAfterDelete.ContainsKey(testKey2));
+        Assert.Equal(updatedText1, notebookAfterDelete[testPage1]);
+        Assert.False(notebookAfterDelete.ContainsKey(testPage2));
 
-        // 8a. Reading deleted entry returns empty
-        string deletedValue = await _notebookTools.GetEntryAsync(notebookName, testKey2);
-        Assert.Equal(string.Empty, deletedValue);
+        // 8a. Reading deleted page returns empty
+        string deletedText = await _notebookTools.GetPageTextAsync(notebookName, testPage2);
+        Assert.Equal(string.Empty, deletedText);
 
-        // 9. Try to delete non-existent entry
-        bool deleteNonExistentResult = await _notebookTools.RemoveEntryAsync(notebookName, "non-existent-key");
+        // 9. Try to delete non-existent page
+        bool deleteNonExistentResult = await _notebookTools.RemovePageAsync(notebookName, "non-existent-page");
         Assert.False(deleteNonExistentResult);
 
-        // 10. Delete the last entry
-        bool deleteLastResult = await _notebookTools.RemoveEntryAsync(notebookName, testKey1);
+        // 10. Delete the last page
+        bool deleteLastResult = await _notebookTools.RemovePageAsync(notebookName, testPage1);
         Assert.True(deleteLastResult);
 
         // 11. Verify notebook is empty but still exists
-        Dictionary<string, string> finalNotebook = await _notebookTools.GetNotebookEntriesAsync(notebookName);
+        Dictionary<string, string> finalNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
         Assert.NotNull(finalNotebook);
         Assert.Empty(finalNotebook);
     }
@@ -142,22 +142,22 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         // Arrange
         const string notebook1 = "notebook-one";
         const string notebook2 = "notebook-two";
-        const string commonKey = "common-key";
-        const string value1 = "value-from-notebook-one";
-        const string value2 = "value-from-notebook-two";
+        const string commonPage = "common-page";
+        const string text1 = "text-from-notebook-one";
+        const string text2 = "text-from-notebook-two";
 
         // Act
-        await _notebookTools.UpsertEntryAsync(notebook1, commonKey, value1);
-        await _notebookTools.UpsertEntryAsync(notebook2, commonKey, value2);
+        await _notebookTools.UpsertPageAsync(notebook1, commonPage, text1);
+        await _notebookTools.UpsertPageAsync(notebook2, commonPage, text2);
 
         // Assert
-        Dictionary<string, string> notebook1Data = await _notebookTools.GetNotebookEntriesAsync(notebook1);
-        Dictionary<string, string> notebook2Data = await _notebookTools.GetNotebookEntriesAsync(notebook2);
+        Dictionary<string, string> notebook1Data = await _notebookTools.GetNotebookPagesAsync(notebook1);
+        Dictionary<string, string> notebook2Data = await _notebookTools.GetNotebookPagesAsync(notebook2);
 
         Assert.Single(notebook1Data);
         Assert.Single(notebook2Data);
-        Assert.Equal(value1, notebook1Data[commonKey]);
-        Assert.Equal(value2, notebook2Data[commonKey]);
+        Assert.Equal(text1, notebook1Data[commonPage]);
+        Assert.Equal(text2, notebook2Data[commonPage]);
     }
 
     [Fact]
@@ -165,52 +165,52 @@ public class NotebookMcpServerIntegrationTests : IDisposable
     {
         // Arrange
         const string notebookName = "large-data-test";
-        const int entriesCount = 100;
+        const int pagesCount = 100;
         Dictionary<string, string> testData = new();
 
         // Generate test data
-        for (int i = 0; i < entriesCount; i++)
+        for (int i = 0; i < pagesCount; i++)
         {
-            testData[$"key-{i:000}"] = $"value-{i:000}-{Guid.NewGuid()}";
+            testData[$"page-{i:000}"] = $"text-{i:000}-{Guid.NewGuid()}";
         }
 
-        // Act: Write all entries
-        foreach ((string key, string value) in testData)
+        // Act: Write all pages
+        foreach ((string page, string text) in testData)
         {
-            await _notebookTools.UpsertEntryAsync(notebookName, key, value);
+            await _notebookTools.UpsertPageAsync(notebookName, page, text);
         }
 
-        // Assert: Verify all entries were written correctly
-        Dictionary<string, string> notebookData = await _notebookTools.GetNotebookEntriesAsync(notebookName);
-        Assert.Equal(entriesCount, notebookData.Count);
+        // Assert: Verify all pages were written correctly
+        Dictionary<string, string> notebookData = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        Assert.Equal(pagesCount, notebookData.Count);
 
-        foreach ((string key, string expectedValue) in testData)
+        foreach ((string page, string expectedText) in testData)
         {
-            Assert.True(notebookData.ContainsKey(key), $"Key '{key}' not found in notebook");
-            Assert.Equal(expectedValue, notebookData[key]);
+            Assert.True(notebookData.ContainsKey(page), $"Page '{page}' not found in notebook");
+            Assert.Equal(expectedText, notebookData[page]);
         }
 
-        // Act: Delete half of the entries
-        List<string> keysToDelete = testData.Keys.Take(entriesCount / 2).ToList();
-        foreach (string? key in keysToDelete)
+        // Act: Delete half of the pages
+        List<string> pagesToDelete = testData.Keys.Take(pagesCount / 2).ToList();
+        foreach (string? page in pagesToDelete)
         {
-            bool deleteResult = await _notebookTools.RemoveEntryAsync(notebookName, key);
-            Assert.True(deleteResult, $"Failed to delete key '{key}'");
+            bool deleteResult = await _notebookTools.RemovePageAsync(notebookName, page);
+            Assert.True(deleteResult, $"Failed to delete page '{page}'");
         }
 
-        // Assert: Verify correct entries remain
-        Dictionary<string, string> finalNotebookData = await _notebookTools.GetNotebookEntriesAsync(notebookName);
-        Assert.Equal(entriesCount - keysToDelete.Count, finalNotebookData.Count);
+        // Assert: Verify correct pages remain
+        Dictionary<string, string> finalNotebookData = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        Assert.Equal(pagesCount - pagesToDelete.Count, finalNotebookData.Count);
 
-        foreach (string? deletedKey in keysToDelete)
+        foreach (string? deletedPage in pagesToDelete)
         {
-            Assert.False(finalNotebookData.ContainsKey(deletedKey), $"Deleted key '{deletedKey}' still exists");
+            Assert.False(finalNotebookData.ContainsKey(deletedPage), $"Deleted page '{deletedPage}' still exists");
         }
 
-        foreach (string? remainingKey in testData.Keys.Except(keysToDelete))
+        foreach (string? remainingPage in testData.Keys.Except(pagesToDelete))
         {
-            Assert.True(finalNotebookData.ContainsKey(remainingKey), $"Remaining key '{remainingKey}' is missing");
-            Assert.Equal(testData[remainingKey], finalNotebookData[remainingKey]);
+            Assert.True(finalNotebookData.ContainsKey(remainingPage), $"Remaining page '{remainingPage}' is missing");
+            Assert.Equal(testData[remainingPage], finalNotebookData[remainingPage]);
         }
     }
 
@@ -221,29 +221,29 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         const string notebookName = "special-chars-test";
         Dictionary<string, string> specialTestCases = new()
         {
-            ["unicode-key-🎯"] = "unicode-value-🚀",
-            ["json-like"] = """{"nested": "value", "array": [1, 2, 3]}""",
+            ["unicode-page-🎯"] = "unicode-text-🚀",
+            ["json-like"] = """{"nested": "text", "array": [1, 2, 3]}""",
             ["multiline"] = "Line 1\nLine 2\nLine 3",
             ["empty"] = "",
             ["whitespace"] = "  \t  ",
-            ["xml-like"] = "<root><item>value</item></root>",
+            ["xml-like"] = "<root><item>text</item></root>",
             ["special-chars"] = "!@#$%^&*()_+-=[]{}|;:,.<>?",
         };
 
         // Act & Assert
-        foreach ((string key, string value) in specialTestCases)
+        foreach ((string page, string text) in specialTestCases)
         {
-            string writeResult = await _notebookTools.UpsertEntryAsync(notebookName, key, value);
+            string writeResult = await _notebookTools.UpsertPageAsync(notebookName, page, text);
             Assert.Contains("has been upserted", writeResult);
         }
 
-        Dictionary<string, string> notebookData = await _notebookTools.GetNotebookEntriesAsync(notebookName);
+        Dictionary<string, string> notebookData = await _notebookTools.GetNotebookPagesAsync(notebookName);
         Assert.Equal(specialTestCases.Count, notebookData.Count);
 
-        foreach ((string key, string expectedValue) in specialTestCases)
+        foreach ((string page, string expectedText) in specialTestCases)
         {
-            Assert.True(notebookData.ContainsKey(key), $"Key '{key}' not found");
-            Assert.Equal(expectedValue, notebookData[key]);
+            Assert.True(notebookData.ContainsKey(page), $"Page '{page}' not found");
+            Assert.Equal(expectedText, notebookData[page]);
         }
     }
 
@@ -252,17 +252,17 @@ public class NotebookMcpServerIntegrationTests : IDisposable
     {
         const string notebookName = "unicode-test";
         const string description = "описание";
-        const string key = "ключ";
-        const string value = "значение";
+        const string page = "ключ";
+        const string text = "значение";
 
         await _notebookTools.CreateNotebookAsync(notebookName, description);
-        await _notebookTools.UpsertEntryAsync(notebookName, key, value);
+        await _notebookTools.UpsertPageAsync(notebookName, page, text);
 
         var filePath = Path.Combine(_testStorageDirectory, $"{notebookName}.json");
         var content = await File.ReadAllTextAsync(filePath);
 
         Assert.Contains(description, content);
-        Assert.Contains(value, content);
+        Assert.Contains(text, content);
         Assert.DoesNotContain("\\u", content);
     }
 
@@ -274,7 +274,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         const int concurrentTasks = 10;
         const int operationsPerTask = 20;
 
-        ConcurrentBag<string> writtenKeys = new();
+        ConcurrentBag<string> writtenPages = new();
 
         // Act: Run concurrent write operations
         List<Task> tasks = new();
@@ -285,11 +285,11 @@ public class NotebookMcpServerIntegrationTests : IDisposable
             {
                 for (int op = 0; op < operationsPerTask; op++)
                 {
-                    string key = $"task-{currentTaskId:00}-key-{op:00}";
-                    string value = $"task-{currentTaskId:00}-value-{op:00}-{DateTime.UtcNow:HH:mm:ss.fff}";
+                    string page = $"task-{currentTaskId:00}-page-{op:00}";
+                    string text = $"task-{currentTaskId:00}-text-{op:00}-{DateTime.UtcNow:HH:mm:ss.fff}";
 
-                    await _notebookTools.UpsertEntryAsync(notebookName, key, value);
-                    writtenKeys.Add(key);
+                    await _notebookTools.UpsertPageAsync(notebookName, page, text);
+                    writtenPages.Add(page);
 
                     // Add small random delay to increase chance of race conditions
                     await Task.Delay(Random.Shared.Next(1, 5));
@@ -299,31 +299,31 @@ public class NotebookMcpServerIntegrationTests : IDisposable
 
         await Task.WhenAll(tasks);
 
-        // Assert: Verify all entries were written correctly
-        Dictionary<string, string> finalNotebook = await _notebookTools.GetNotebookEntriesAsync(notebookName);
+        // Assert: Verify all pages were written correctly
+        Dictionary<string, string> finalNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
         int expectedCount = concurrentTasks * operationsPerTask;
 
         // Note: Due to potential race conditions in the current implementation,
         // we'll be flexible with the exact count but verify data integrity
-        Assert.True(finalNotebook.Count > 0, "Should have some entries");
+        Assert.True(finalNotebook.Count > 0, "Should have some pages");
         Assert.True(finalNotebook.Count <= expectedCount, "Should not exceed expected count");
 
-        // Verify that all existing entries have the correct format and are unique
-        HashSet<string> uniqueKeys = new();
+        // Verify that all existing pages have the correct format and are unique
+        HashSet<string> uniquePages = new();
         foreach (KeyValuePair<string, string> kvp in finalNotebook)
         {
-            Assert.True(uniqueKeys.Add(kvp.Key), $"Duplicate key found: {kvp.Key}");
-            Assert.Matches(@"task-\d{2}-key-\d{2}", kvp.Key);
-            Assert.Matches(@"task-\d{2}-value-\d{2}-\d{2}:\d{2}:\d{2}\.\d{3}", kvp.Value);
+            Assert.True(uniquePages.Add(kvp.Key), $"Duplicate page found: {kvp.Key}");
+            Assert.Matches(@"task-\d{2}-page-\d{2}", kvp.Key);
+            Assert.Matches(@"task-\d{2}-text-\d{2}-\d{2}:\d{2}:\d{2}\.\d{3}", kvp.Value);
         }
 
         // Log information about what was actually saved vs expected
-        Console.WriteLine($"Expected: {expectedCount} entries, Actual: {finalNotebook.Count} entries");
+        Console.WriteLine($"Expected: {expectedCount} pages, Actual: {finalNotebook.Count} pages");
         if (finalNotebook.Count < expectedCount)
         {
-            List<string> writtenKeysList = writtenKeys.ToList();
-            List<string> missingKeys = writtenKeysList.Except(finalNotebook.Keys).Take(5).ToList();
-            Console.WriteLine($"Some entries may have been lost due to concurrent access. Sample missing keys: {string.Join(", ", missingKeys)}");
+            List<string> writtenPagesList = writtenPages.ToList();
+            List<string> missingPages = writtenPagesList.Except(finalNotebook.Keys).Take(5).ToList();
+            Console.WriteLine($"Some pages may have been lost due to concurrent access. Sample missing pages: {string.Join(", ", missingPages)}");
         }
     }
 
@@ -332,20 +332,20 @@ public class NotebookMcpServerIntegrationTests : IDisposable
     {
         // Arrange
         const string notebookName = "persistence-test";
-        const string testKey = "persistent-key";
-        const string testValue = "persistent-value";
+        const string testPage = "persistent-page";
+        const string testText = "persistent-text";
 
         // Act: Write data with first service instance
-        await _notebookTools.UpsertEntryAsync(notebookName, testKey, testValue);
+        await _notebookTools.UpsertPageAsync(notebookName, testPage, testText);
 
         // Simulate service restart by creating new service instances
         ServiceProvider newServiceProvider = CreateNewServiceProvider();
         NotebookTools newNotebookTools = newServiceProvider.GetRequiredService<NotebookTools>();
 
         // Assert: Data should still exist
-        Dictionary<string, string> restoredNotebook = await newNotebookTools.GetNotebookEntriesAsync(notebookName);
+        Dictionary<string, string> restoredNotebook = await newNotebookTools.GetNotebookPagesAsync(notebookName);
         Assert.Single(restoredNotebook);
-        Assert.Equal(testValue, restoredNotebook[testKey]);
+        Assert.Equal(testText, restoredNotebook[testPage]);
 
         // Cleanup
         newServiceProvider.Dispose();
@@ -444,8 +444,8 @@ internal class TestFileNotebookStorageService : INotebookStorageService, IDispos
             Notebook? notebook = await JsonSerializer.DeserializeAsync<Notebook>(stream, JsonOptions, cancellationToken);
 
             _logger.LogDebug(
-                "Successfully loaded notebook '{NotebookName}' with {EntryCount} entries",
-                notebookName, notebook?.Entries.Count ?? 0);
+                "Successfully loaded notebook '{NotebookName}' with {PageCount} pages",
+                notebookName, notebook?.Pages.Count ?? 0);
 
             return notebook;
         }
@@ -485,8 +485,8 @@ internal class TestFileNotebookStorageService : INotebookStorageService, IDispos
             await stream.FlushAsync(cancellationToken);
 
             _logger.LogDebug(
-                "Successfully saved notebook '{NotebookName}' with {EntryCount} entries",
-                notebook.Name, notebook.Entries.Count);
+                "Successfully saved notebook '{NotebookName}' with {PageCount} pages",
+                notebook.Name, notebook.Pages.Count);
         }
         catch (Exception ex)
         {

--- a/tests/NotebookMcpServer.Tests/NotebookServiceTests.cs
+++ b/tests/NotebookMcpServer.Tests/NotebookServiceTests.cs
@@ -34,176 +34,158 @@ public class NotebookServiceTests
     }
 
     [Fact]
-    public async Task GetEntryAsync_NonexistentNotebook_ReturnsEmptyString()
+    public async Task GetPageAsync_NonexistentNotebook_ReturnsEmptyString()
     {
         var (_, notebookService) = CreateServices();
 
-        var result = await notebookService.GetEntryAsync("missing", "key");
+        var result = await notebookService.GetPageAsync("missing", "page");
 
         Assert.Equal(string.Empty, result);
     }
 
     [Fact]
-    public async Task GetEntryAsync_NonexistentKey_ReturnsEmptyString()
+    public async Task GetPageAsync_NonexistentPage_ReturnsEmptyString()
     {
         var (_, notebookService) = CreateServices();
 
-        await notebookService.WriteEntryAsync("book", "existing", "value");
+        await notebookService.WritePageAsync("book", "existing", "text");
 
-        var result = await notebookService.GetEntryAsync("book", "missing");
+        var result = await notebookService.GetPageAsync("book", "missing");
 
         Assert.Equal(string.Empty, result);
     }
 
     [Fact]
-    public async Task GetEntryAsync_ExistingEntry_ReturnsValue()
+    public async Task GetPageAsync_ExistingPage_ReturnsText()
     {
         var (_, notebookService) = CreateServices();
 
-        await notebookService.WriteEntryAsync("book", "key", "value");
+        await notebookService.WritePageAsync("book", "page", "text");
 
-        var result = await notebookService.GetEntryAsync("book", "key");
+        var result = await notebookService.GetPageAsync("book", "page");
 
-        Assert.Equal("value", result);
+        Assert.Equal("text", result);
     }
 
     [Fact]
-    public async Task WriteEntryAsync_NewNotebook_CreatesNotebookAndEntry()
+    public async Task WritePageAsync_NewNotebook_CreatesNotebookAndPage()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "test-notebook";
-        const string key = "test-key";
-        const string value = "test-value";
+        const string page = "test-page";
+        const string text = "test-text";
 
         // Act
-        await notebookService.WriteEntryAsync(notebookName, key, value);
+        await notebookService.WritePageAsync(notebookName, page, text);
 
         // Assert
         var result = await notebookService.ViewNotebookAsync(notebookName);
         Assert.Single(result);
-        Assert.Equal(value, result[key]);
+        Assert.Equal(text, result[page]);
     }
 
     [Fact]
-    public async Task WriteEntryAsync_ExistingKey_UpdatesEntry()
+    public async Task WritePageAsync_ExistingPage_UpdatesPage()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "test-notebook";
-        const string key = "test-key";
-        const string originalValue = "original-value";
-        const string updatedValue = "updated-value";
+        const string page = "test-page";
+        const string originalText = "original-text";
+        const string updatedText = "updated-text";
 
         // Act
-        await notebookService.WriteEntryAsync(notebookName, key, originalValue);
-        await notebookService.WriteEntryAsync(notebookName, key, updatedValue);
+        await notebookService.WritePageAsync(notebookName, page, originalText);
+        await notebookService.WritePageAsync(notebookName, page, updatedText);
 
         // Assert
         var result = await notebookService.ViewNotebookAsync(notebookName);
         Assert.Single(result);
-        Assert.Equal(updatedValue, result[key]);
+        Assert.Equal(updatedText, result[page]);
     }
 
     [Fact]
-    public async Task DeleteEntryAsync_ExistingEntry_DeletesEntryAndReturnsTrue()
+    public async Task DeletePageAsync_ExistingPage_DeletesPageAndReturnsTrue()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "test-notebook";
-        const string key = "test-key";
-        const string value = "test-value";
+        const string page = "test-page";
+        const string text = "test-text";
 
-        await notebookService.WriteEntryAsync(notebookName, key, value);
+        await notebookService.WritePageAsync(notebookName, page, text);
 
         // Act
-        var result = await notebookService.DeleteEntryAsync(notebookName, key);
+        var result = await notebookService.DeletePageAsync(notebookName, page);
 
         // Assert
         Assert.True(result);
-        var entries = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Empty(entries);
+        var pages = await notebookService.ViewNotebookAsync(notebookName);
+        Assert.Empty(pages);
     }
 
     [Fact]
-    public async Task DeleteEntryAsync_NonExistentEntry_ReturnsFalse()
+    public async Task DeletePageAsync_NonExistentPage_ReturnsFalse()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "test-notebook";
-        const string key = "nonexistent-key";
+        const string page = "nonexistent-page";
 
         // Act
-        var result = await notebookService.DeleteEntryAsync(notebookName, key);
+        var result = await notebookService.DeletePageAsync(notebookName, page);
 
         // Assert
         Assert.False(result);
     }
 
     [Fact]
-    public async Task DeleteEntryAsync_NonExistentNotebook_ReturnsFalse()
+    public async Task DeletePageAsync_NonExistentNotebook_ReturnsFalse()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "nonexistent-notebook";
-        const string key = "test-key";
+        const string page = "test-page";
 
         // Act
-        var result = await notebookService.DeleteEntryAsync(notebookName, key);
+        var result = await notebookService.DeletePageAsync(notebookName, page);
 
         // Assert
         Assert.False(result);
     }
 
     [Fact]
-    public async Task WriteEntryAsync_EmptyValue_StoresEmptyString()
+    public async Task WritePageAsync_MultiplePages_StoresAllPages()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "test-notebook";
-        const string key = "test-key";
-
-        // Act
-        await notebookService.WriteEntryAsync(notebookName, key, "");
-
-        // Assert
-        var result = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Single(result);
-        Assert.Equal("", result[key]);
-    }
-
-    [Fact]
-    public async Task WriteEntryAsync_MultipleEntries_StoresAllEntries()
-    {
-        var (storageService, notebookService) = CreateServices();
-        
-        // Arrange
-        const string notebookName = "test-notebook";
-        var entries = new Dictionary<string, string>
+        var pages = new Dictionary<string, string>
         {
-            ["key1"] = "value1",
-            ["key2"] = "value2",
-            ["key3"] = "value3"
+            ["page1"] = "text1",
+            ["page2"] = "text2",
+            ["page3"] = "text3"
         };
 
         // Act
-        foreach (var (key, value) in entries)
+        foreach (var (page, text) in pages)
         {
-            await notebookService.WriteEntryAsync(notebookName, key, value);
+            await notebookService.WritePageAsync(notebookName, page, text);
         }
 
         // Assert
         var result = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Equal(entries.Count, result.Count);
-        foreach (var (key, expectedValue) in entries)
+        Assert.Equal(pages.Count, result.Count);
+        foreach (var (page, expectedText) in pages)
         {
-            Assert.Equal(expectedValue, result[key]);
+            Assert.Equal(expectedText, result[page]);
         }
     }
 
@@ -231,65 +213,65 @@ public class NotebookServiceTests
     }
 
     [Fact]
-    public async Task WriteEntryAsync_NullNotebookName_ThrowsArgumentException()
+    public async Task WritePageAsync_NullNotebookName_ThrowsArgumentException()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
-            () => notebookService.WriteEntryAsync(null!, "key", "value"));
+            () => notebookService.WritePageAsync(null!, "page", "text"));
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("  ")]
-    public async Task WriteEntryAsync_InvalidNotebookName_ThrowsArgumentException(string invalidName)
+    public async Task WritePageAsync_InvalidNotebookName_ThrowsArgumentException(string invalidName)
     {
         var (storageService, notebookService) = CreateServices();
         
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(
-            () => notebookService.WriteEntryAsync(invalidName, "key", "value"));
+            () => notebookService.WritePageAsync(invalidName, "page", "text"));
     }
 
     [Fact]
-    public async Task WriteEntryAsync_NullKey_ThrowsArgumentException()
+    public async Task WritePageAsync_NullPage_ThrowsArgumentException()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
-            () => notebookService.WriteEntryAsync("notebook", null!, "value"));
+            () => notebookService.WritePageAsync("notebook", null!, "text"));
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("  ")]
-    public async Task WriteEntryAsync_InvalidKey_ThrowsArgumentException(string invalidKey)
+    public async Task WritePageAsync_InvalidPage_ThrowsArgumentException(string invalidPage)
     {
         var (storageService, notebookService) = CreateServices();
         
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(
-            () => notebookService.WriteEntryAsync("notebook", invalidKey, "value"));
+            () => notebookService.WritePageAsync("notebook", invalidPage, "text"));
     }
 
     [Fact]
-    public async Task WriteEntryAsync_NullValue_TreatedAsEmptyString()
+    public async Task WritePageAsync_NullText_TreatedAsEmptyString()
     {
         var (storageService, notebookService) = CreateServices();
         
         // Arrange
         const string notebookName = "test-notebook";
-        const string key = "test-key";
+        const string page = "test-page";
 
         // Act
-        await notebookService.WriteEntryAsync(notebookName, key, null!);
+        await notebookService.WritePageAsync(notebookName, page, null!);
 
         // Assert
         var result = await notebookService.ViewNotebookAsync(notebookName);
         Assert.Single(result);
-        Assert.Equal("", result[key]);
+        Assert.Equal("", result[page]);
     }
 }
 


### PR DESCRIPTION
## Summary
- rename notebook entries to pages and values to text
- update services, tools, and documentation for page/text terminology
- drop redundant empty-value test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8226f7fb4832a9332bb979fc10e39