### PR TITLE
Return notebook summaries without page content

### DIFF
--- a/src/NotebookMcpServer/Interfaces/INotebookService.cs
+++ b/src/NotebookMcpServer/Interfaces/INotebookService.cs
@@ -8,12 +8,12 @@ namespace NotebookMcpServer.Interfaces;
 public interface INotebookService
 {
     /// <summary>
-    /// Get all pages from a notebook
+    /// Get notebook description and page titles
     /// </summary>
     /// <param name="notebookName">Name of the notebook</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Dictionary of all pages in the notebook</returns>
-    Task<Dictionary<string, string>> ViewNotebookAsync(string notebookName, CancellationToken cancellationToken = default);
+    /// <returns>Notebook summary</returns>
+    Task<NotebookSummary> ViewNotebookAsync(string notebookName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get text of a single page from a notebook

--- a/src/NotebookMcpServer/Models/NotebookSummary.cs
+++ b/src/NotebookMcpServer/Models/NotebookSummary.cs
@@ -1,0 +1,10 @@
+namespace NotebookMcpServer.Models;
+
+/// <summary>
+/// Notebook description with page titles.
+/// </summary>
+public record NotebookSummary
+{
+    public string? Description { get; init; }
+    public List<string> Pages { get; init; } = [];
+}

--- a/src/NotebookMcpServer/Services/NotebookService.cs
+++ b/src/NotebookMcpServer/Services/NotebookService.cs
@@ -18,7 +18,7 @@ public class NotebookService : INotebookService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<Dictionary<string, string>> ViewNotebookAsync(string notebookName, CancellationToken cancellationToken = default)
+    public async Task<NotebookSummary> ViewNotebookAsync(string notebookName, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(notebookName);
 
@@ -29,17 +29,17 @@ public class NotebookService : INotebookService
         if (notebook == null)
         {
             _logger.LogInformation("Notebook '{NotebookName}' not found, returning empty result", notebookName);
-            return new Dictionary<string, string>();
+            return new NotebookSummary();
         }
 
-        var result = notebook.Pages.ToDictionary(
-            kvp => kvp.Key,
-            kvp => kvp.Value.Text,
-            StringComparer.OrdinalIgnoreCase
-        );
+        var pages = notebook.Pages.Keys.ToList();
 
-        _logger.LogInformation("Notebook '{NotebookName}' contains {PageCount} pages", notebookName, result.Count);
-        return result;
+        _logger.LogInformation("Notebook '{NotebookName}' contains {PageCount} pages", notebookName, pages.Count);
+        return new NotebookSummary
+        {
+            Description = notebook.Description,
+            Pages = pages
+        };
     }
 
     public async Task<string> GetPageAsync(string notebookName, string page, CancellationToken cancellationToken = default)

--- a/src/NotebookMcpServer/Tools/NotebookTools.cs
+++ b/src/NotebookMcpServer/Tools/NotebookTools.cs
@@ -1,5 +1,6 @@
-﻿using ModelContextProtocol.Server;
+using ModelContextProtocol.Server;
 using NotebookMcpServer.Interfaces;
+using NotebookMcpServer.Models;
 using System.ComponentModel;
 
 namespace NotebookMcpServer.Tools;
@@ -38,13 +39,13 @@ public class NotebookTools
     }
 
     /// <summary>
-    /// Returns all pages of the specified notebook as a dictionary (page → text).
+    /// Returns notebook description and page titles.
     /// </summary>
     /// <param name="notebookName">Name of the target notebook (case-insensitive, non-empty).</param>
-    /// <returns>A dictionary of current pages in the notebook.</returns>
+    /// <returns>Notebook summary.</returns>
     [McpServerTool(Name = "get_notebook_pages")]
-    [Description("List all pages in the specified notebook.")]
-    public async Task<Dictionary<string, string>> GetNotebookPagesAsync(
+    [Description("List notebook description and page titles.")]
+    public async Task<NotebookSummary> GetNotebookPagesAsync(
             [Description("Name of the notebook to read (case-insensitive, non-empty).")]
             string notebookName)
     {

--- a/tests/NotebookMcpServer.Tests/NotebookServiceTests.cs
+++ b/tests/NotebookMcpServer.Tests/NotebookServiceTests.cs
@@ -21,7 +21,7 @@ public class NotebookServiceTests
     }
 
     [Fact]
-    public async Task ViewNotebookAsync_NewNotebook_ReturnsEmptyDictionary()
+    public async Task ViewNotebookAsync_NewNotebook_ReturnsEmptySummary()
     {
         var (storageService, notebookService) = CreateServices();
 
@@ -30,7 +30,7 @@ public class NotebookServiceTests
 
         // Assert
         Assert.NotNull(result);
-        Assert.Empty(result);
+        Assert.Empty(result.Pages);
     }
 
     [Fact]
@@ -81,9 +81,10 @@ public class NotebookServiceTests
         await notebookService.WritePageAsync(notebookName, page, text);
 
         // Assert
-        var result = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Single(result);
-        Assert.Equal(text, result[page]);
+        var summary = await notebookService.ViewNotebookAsync(notebookName);
+        Assert.Contains(page, summary.Pages);
+        var storedText = await notebookService.GetPageAsync(notebookName, page);
+        Assert.Equal(text, storedText);
     }
 
     [Fact]
@@ -102,9 +103,10 @@ public class NotebookServiceTests
         await notebookService.WritePageAsync(notebookName, page, updatedText);
 
         // Assert
-        var result = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Single(result);
-        Assert.Equal(updatedText, result[page]);
+        var summary = await notebookService.ViewNotebookAsync(notebookName);
+        Assert.Contains(page, summary.Pages);
+        var storedText = await notebookService.GetPageAsync(notebookName, page);
+        Assert.Equal(updatedText, storedText);
     }
 
     [Fact]
@@ -124,8 +126,8 @@ public class NotebookServiceTests
 
         // Assert
         Assert.True(result);
-        var pages = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Empty(pages);
+        var summary = await notebookService.ViewNotebookAsync(notebookName);
+        Assert.Empty(summary.Pages);
     }
 
     [Fact]
@@ -181,11 +183,13 @@ public class NotebookServiceTests
         }
 
         // Assert
-        var result = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Equal(pages.Count, result.Count);
+        var summary = await notebookService.ViewNotebookAsync(notebookName);
+        Assert.Equal(pages.Count, summary.Pages.Count);
         foreach (var (page, expectedText) in pages)
         {
-            Assert.Equal(expectedText, result[page]);
+            Assert.Contains(page, summary.Pages);
+            var text = await notebookService.GetPageAsync(notebookName, page);
+            Assert.Equal(expectedText, text);
         }
     }
 
@@ -269,9 +273,10 @@ public class NotebookServiceTests
         await notebookService.WritePageAsync(notebookName, page, null!);
 
         // Assert
-        var result = await notebookService.ViewNotebookAsync(notebookName);
-        Assert.Single(result);
-        Assert.Equal("", result[page]);
+        var summary = await notebookService.ViewNotebookAsync(notebookName);
+        Assert.Single(summary.Pages);
+        var text = await notebookService.GetPageAsync(notebookName, page);
+        Assert.Equal("", text);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- show notebook description and page titles without content
- retrieve page text through dedicated command
- adjust tests for new notebook summary behavior

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8842d7bd4832a8f6e1c442cf58f31