### PR TITLE
Remove redundant page field from notebook pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ The JSON structure includes:
   "Name": "my-notebook",
   "Pages": {
     "page1": {
-      "Page": "page1",
       "Text": "text1",
       "CreatedAt": "2024-01-15T10:30:00Z",
       "ModifiedAt": "2024-01-15T10:30:00Z"
@@ -106,6 +105,7 @@ The JSON structure includes:
   "ModifiedAt": "2024-01-15T10:30:00Z"
 }
 ```
+Page names appear as keys under `Pages` and are not repeated inside each entry.
 
 ## Building and Running
 

--- a/src/NotebookMcpServer/Models/NotebookPage.cs
+++ b/src/NotebookMcpServer/Models/NotebookPage.cs
@@ -5,7 +5,6 @@ namespace NotebookMcpServer.Models;
 /// </summary>
 public record NotebookPage
 {
-    public required string Page { get; init; }
     public required string Text { get; init; }
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
     public DateTime ModifiedAt { get; init; } = DateTime.UtcNow;

--- a/src/NotebookMcpServer/Services/NotebookService.cs
+++ b/src/NotebookMcpServer/Services/NotebookService.cs
@@ -85,7 +85,6 @@ public class NotebookService : INotebookService
         var now = DateTime.UtcNow;
         var pageData = new NotebookPage
         {
-            Page = page,
             Text = text,
             CreatedAt = notebook.Pages.ContainsKey(page) ? notebook.Pages[page].CreatedAt : now,
             ModifiedAt = now


### PR DESCRIPTION
## Summary
- drop `Page` property from `NotebookPage` so notebook entries rely on dictionary keys
- stop writing the removed field when saving pages
- document that page names are taken from the `Pages` dictionary keys

## Testing
- `dotnet test --no-build -v:minimal`

------
https://chatgpt.com/codex/tasks/task_e_68b8880fcf28832abe099a3c64a17759