### PR TITLE
Rename get_notebook_pages tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ This MCP server provides tools for creating, viewing, updating, and managing not
 
 ## Available Tools
 
-### 1. Get Notebook Pages (`get_notebook_pages`)
-Retrieves all pages with their text from a notebook.
+### 1. Get Notebook Page Names (`get_notebook_page_names`)
+Retrieves notebook description and page names without page text.
 
 **Parameters:**
 - `notebook_name` (string): Name of the notebook to view
 
-**Returns:** Dictionary of page-text pairs
+**Returns:** Notebook description and list of page names
 
 **Example:**
 ```json
@@ -260,7 +260,7 @@ The server uses semaphores to ensure thread-safe file operations:
 This server is designed to work with MCP-compatible clients. The client connects via stdio and can invoke the available tools to manage notebooks.
 
 Example workflow:
-1. Use `get_notebook_pages` to check existing pages
+1. Use `get_notebook_page_names` to check existing pages
 2. Use `upsert_page` to add or update pages
 3. Use `remove_page` to remove obsolete pages
 

--- a/src/NotebookMcpServer/Tools/NotebookTools.cs
+++ b/src/NotebookMcpServer/Tools/NotebookTools.cs
@@ -39,13 +39,13 @@ public class NotebookTools
     }
 
     /// <summary>
-    /// Returns notebook description and page titles.
+    /// Returns notebook description and page names without page content.
     /// </summary>
     /// <param name="notebookName">Name of the target notebook (case-insensitive, non-empty).</param>
     /// <returns>Notebook summary.</returns>
-    [McpServerTool(Name = "get_notebook_pages")]
-    [Description("List notebook description and page titles.")]
-    public async Task<NotebookSummary> GetNotebookPagesAsync(
+    [McpServerTool(Name = "get_notebook_page_names")]
+    [Description("Get notebook description and page names without page text.")]
+    public async Task<NotebookSummary> GetNotebookPageNamesAsync(
             [Description("Name of the notebook to read (case-insensitive, non-empty).")]
             string notebookName)
     {

--- a/tests/NotebookMcpServer.Tests/NotebookMcpServerIntegrationTests.cs
+++ b/tests/NotebookMcpServer.Tests/NotebookMcpServerIntegrationTests.cs
@@ -67,7 +67,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         // Act & Assert: CREATE operations
 
         // 1. View empty notebook (should return empty summary)
-        NotebookSummary emptyNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary emptyNotebook = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.NotNull(emptyNotebook);
         Assert.Empty(emptyNotebook.Pages);
 
@@ -88,7 +88,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         // Act & Assert: READ operations
 
         // 4. View notebook with pages
-        NotebookSummary notebookWithPages = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary notebookWithPages = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.NotNull(notebookWithPages);
         Assert.Equal(2, notebookWithPages.Pages.Count);
         Assert.Contains(testPage1, notebookWithPages.Pages);
@@ -105,7 +105,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         Assert.Contains("has been upserted", updateResult);
 
         // 6. Verify update
-        NotebookSummary updatedNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary updatedNotebook = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.Equal(2, updatedNotebook.Pages.Count);
         Assert.Contains(testPage1, updatedNotebook.Pages);
         Assert.Contains(testPage2, updatedNotebook.Pages);
@@ -121,7 +121,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         Assert.True(deleteResult);
 
         // 8. Verify deletion
-        NotebookSummary notebookAfterDelete = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary notebookAfterDelete = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.Single(notebookAfterDelete.Pages);
         Assert.Contains(testPage1, notebookAfterDelete.Pages);
         string remainingText = await _notebookTools.GetPageTextAsync(notebookName, testPage1);
@@ -141,7 +141,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         Assert.True(deleteLastResult);
 
         // 11. Verify notebook is empty but still exists
-        NotebookSummary finalNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary finalNotebook = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.NotNull(finalNotebook);
         Assert.Empty(finalNotebook.Pages);
     }
@@ -161,8 +161,8 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         await _notebookTools.UpsertPageAsync(notebook2, commonPage, text2);
 
         // Assert
-        NotebookSummary notebook1Data = await _notebookTools.GetNotebookPagesAsync(notebook1);
-        NotebookSummary notebook2Data = await _notebookTools.GetNotebookPagesAsync(notebook2);
+        NotebookSummary notebook1Data = await _notebookTools.GetNotebookPageNamesAsync(notebook1);
+        NotebookSummary notebook2Data = await _notebookTools.GetNotebookPageNamesAsync(notebook2);
 
         Assert.Single(notebook1Data.Pages);
         Assert.Single(notebook2Data.Pages);
@@ -191,7 +191,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         }
 
         // Assert: Verify all pages were written correctly
-        NotebookSummary notebookData = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary notebookData = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.Equal(pagesCount, notebookData.Pages.Count);
 
         foreach ((string page, string expectedText) in testData)
@@ -210,7 +210,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         }
 
         // Assert: Verify correct pages remain
-        NotebookSummary finalNotebookData = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary finalNotebookData = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.Equal(pagesCount - pagesToDelete.Count, finalNotebookData.Pages.Count);
 
         foreach (string? deletedPage in pagesToDelete)
@@ -249,7 +249,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
             Assert.Contains("has been upserted", writeResult);
         }
 
-        NotebookSummary notebookData = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary notebookData = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.Equal(specialTestCases.Count, notebookData.Pages.Count);
 
         foreach ((string page, string expectedText) in specialTestCases)
@@ -326,7 +326,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         await Task.WhenAll(tasks);
 
         // Assert: Verify all pages were written correctly
-        NotebookSummary finalNotebook = await _notebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary finalNotebook = await _notebookTools.GetNotebookPageNamesAsync(notebookName);
         int expectedCount = concurrentTasks * operationsPerTask;
 
         // Note: Due to potential race conditions in the current implementation,
@@ -370,7 +370,7 @@ public class NotebookMcpServerIntegrationTests : IDisposable
         NotebookTools newNotebookTools = newServiceProvider.GetRequiredService<NotebookTools>();
 
         // Assert: Data should still exist
-        NotebookSummary restoredNotebook = await newNotebookTools.GetNotebookPagesAsync(notebookName);
+        NotebookSummary restoredNotebook = await newNotebookTools.GetNotebookPageNamesAsync(notebookName);
         Assert.Single(restoredNotebook.Pages);
         string readText = await newNotebookTools.GetPageTextAsync(notebookName, testPage);
         Assert.Equal(testText, readText);


### PR DESCRIPTION
## Summary
- rename `get_notebook_pages` tool to `get_notebook_page_names`
- clarify documentation that tool returns only notebook description and page names
- update tests for the new method name

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b895493f90832a8342c3b6d791b775